### PR TITLE
Condition CI/CD trigger for src/ changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,12 @@ name: Build ROM
 on:
   push:
     branches: [ main, master ]
+    paths: 
+      - 'src/**'
   pull_request:
     branches: [ main, master ]
+    paths: 
+      - 'src/**'
 
 jobs:
   build:


### PR DESCRIPTION
Add `paths` filter to GitHub Actions workflow to trigger only on `src/` folder changes.

This change optimizes CI/CD runs by ignoring changes outside the `src/` directory, reducing unnecessary builds and resource consumption.